### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kgraphviewer.json
+++ b/org.kde.kgraphviewer.json
@@ -12,6 +12,17 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/include/boost",
+        "/lib/cmake/Boost*",
+        "/lib/cmake/boost*",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "/share/qlogging-categories6",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "boost",


### PR DESCRIPTION
The installed size reduced from 175.7 MB to 17.4 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.