### PR TITLE
Update boost, graphviz and kgraphviewer modules; update runtime to 6.11

### DIFF
--- a/org.kde.kgraphviewer.json
+++ b/org.kde.kgraphviewer.json
@@ -27,7 +27,7 @@
             "name": "boost",
             "buildsystem": "simple",
             "build-commands": [
-                "./bootstrap.sh --prefix=/app --with-libraries=spirit",
+                "./bootstrap.sh --prefix=/app --with-libraries=headers",
                 "./b2 -j $FLATPAK_BUILDER_N_JOBS install"
             ],
             "sources": [

--- a/org.kde.kgraphviewer.json
+++ b/org.kde.kgraphviewer.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.kgraphviewer",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.10",
+    "runtime-version": "6.11",
     "sdk": "org.kde.Sdk",
     "command": "kgraphviewer",
     "rename-icon": "kgraphviewer",

--- a/org.kde.kgraphviewer.json
+++ b/org.kde.kgraphviewer.json
@@ -33,8 +33,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.bz2",
-                    "sha256": "49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305",
+                    "url": "https://archives.boost.io/release/1.92.0/source/boost_1_92_0.tar.bz2",
+                    "sha256": "5c1d40cb8e19adbf740a4ec2da35b3e58f3f5804b1dce44deb53df72193cbc6c",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 6845,
@@ -50,8 +50,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/15.1.0/graphviz-15.1.0.tar.xz",
-                    "sha256": "4c44f9f6654d39638db7cdb6a088735117469015299298d82087b24dd4042b16",
+                    "url": "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/16.0.0/graphviz-16.0.0.tar.xz",
+                    "sha256": "9cfb7ccc422e82ef56b01561bab212a9afde75fe65ef884bd3198e6ceea95f6d",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1249,
@@ -70,8 +70,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/26.04.3/src/kgraphviewer-26.04.3.tar.xz",
-                    "sha256": "d10266f6a98ee0234e5edf2f3ddb272a508cb72679553d0030ffebcb3e4099b9",
+                    "url": "https://download.kde.org/stable/release-service/26.08.0/src/kgraphviewer-26.08.0.tar.xz",
+                    "sha256": "955dd7c8119015d960dd883ffe66017f766ec5b5f3a0090257e8983c6df8a381",
                     "x-checker-data": {
                         "is-main-source": true,
                         "type": "anitya",


### PR DESCRIPTION
boost: Update boost_1_90_0.tar.bz2 to 1.92.0
graphviz: Update graphviz-15.1.0.tar.xz to 16.0.0
kgraphviewer: Update kgraphviewer-26.04.3.tar.xz to 26.08.0

Update runtime from 6.10 to 6.11

Based on https://github.com/flathub/org.kde.kgraphviewer/pull/64, but I don't have permissions to push to there.